### PR TITLE
Expand/limiting/reader

### DIFF
--- a/R/read_limiting_stock.R
+++ b/R/read_limiting_stock.R
@@ -13,16 +13,20 @@ read_limiting_stock <- function(filename, longform = FALSE) {
   column.names <- c(
     "Fishery", "FisheryID",
     filename |>
-      readxl::read_excel(range = "LimitingStkComplete mod!L3:DL3", col_names = F) |>
+      readxl::read_excel(range = "LimitingStkComplete mod!L3:DL3", col_names = F, .name_repair = "unique_quiet") |>
       unlist() |> stats::na.omit() |> unique() |> rep(each = 7) |>
       paste(rep(c("t2_aeq", "t3_aeq", "t4_aeq", "t2_er", "t3_er", "t4_er", "yr_er"), 15), sep = "_")
   )
 
   res <- dplyr::bind_rows(
-    readxl::read_excel(filename, range = "LimitingStkComplete mod!J163:DL234", col_names = column.names) |> dplyr::mutate(stock_type = "UM_H"),
-    readxl::read_excel(filename, range = "LimitingStkComplete mod!J242:DL313", col_names = column.names) |> dplyr::mutate(stock_type = "UM_N"),
-    readxl::read_excel(filename, range = "LimitingStkComplete mod!J321:DL392", col_names = column.names) |> dplyr::mutate(stock_type = "M_H"),
-    readxl::read_excel(filename, range = "LimitingStkComplete mod!J400:DL471", col_names = column.names) |> dplyr::mutate(stock_type = "M_N")
+    readxl::read_excel(filename, range = "LimitingStkComplete mod!J163:DL234", col_names = column.names, .name_repair = "unique_quiet") |>
+      dplyr::mutate(stock_type = "UM_H"),
+    readxl::read_excel(filename, range = "LimitingStkComplete mod!J242:DL313", col_names = column.names, .name_repair = "unique_quiet") |>
+      dplyr::mutate(stock_type = "UM_N"),
+    readxl::read_excel(filename, range = "LimitingStkComplete mod!J321:DL392", col_names = column.names, .name_repair = "unique_quiet") |>
+      dplyr::mutate(stock_type = "AD_H"),
+    readxl::read_excel(filename, range = "LimitingStkComplete mod!J400:DL471", col_names = column.names, .name_repair = "unique_quiet") |>
+      dplyr::mutate(stock_type = "AD_N")
   ) |>
     dplyr::mutate(
       fish_type = dplyr::case_when(
@@ -65,7 +69,7 @@ read_limiting_stock <- function(filename, longform = FALSE) {
 #'
 clean_limiting_stock <- function(filename) {
   dat <- read_limiting_stock(filename)
-  run.num <- readxl::read_excel(filename, range = "1!B2", col_names = FALSE)
+  run.num <- readxl::read_excel(filename, range = "1!B2", col_names = FALSE, .name_repair = "unique_quiet")
   if (grepl("Chin", run.num)) {
     attr(dat, "species") <- "CHINOOK"
   }

--- a/R/read_limiting_stock.R
+++ b/R/read_limiting_stock.R
@@ -6,7 +6,7 @@
 #' @param longform Should results be in long form (good for R stuff) (`TRUE`) or replicate the structure of the TAMM sheet (`FALSE`). Logical, defaults to `FALSE`.
 #' @importFrom rlang .data
 #'
-#' @return data frame summarizing the TAMM limiting stock tab.
+#' @return data frame summarizing the TAMM limiting stock tab. The "block" of the limiting tab is identified with column "stock_type", where "ALL_N" is all natural fish (in TAMM, the first block), "ALL_H" is all hatchery fish (in TAMM, block starts on row 81), "UM_H" is unmarked hatchery (in TAMM, starts on row 160), "UM_N" is unmarked naturals (in TAMM, starts row 239), "AD_H" is marked hatchery (in TAMM, starts row 318), and "AD_N" is marked naturals (should be all zeros unless something strange changes in the future; in TAMM starts row 397).
 #' @export
 #'
 read_limiting_stock <- function(filename, longform = FALSE) {
@@ -19,6 +19,10 @@ read_limiting_stock <- function(filename, longform = FALSE) {
   )
 
   res <- dplyr::bind_rows(
+    readxl::read_excel(filename, range = "LimitingStkComplete mod!J5:DL76", col_names = column.names, .name_repair = "unique_quiet") |>
+      dplyr::mutate(stock_type = "ALL_N"),
+    readxl::read_excel(filename, range = "LimitingStkComplete mod!J84:DL155", col_names = column.names, .name_repair = "unique_quiet") |>
+      dplyr::mutate(stock_type = "ALL_H"),
     readxl::read_excel(filename, range = "LimitingStkComplete mod!J163:DL234", col_names = column.names, .name_repair = "unique_quiet") |>
       dplyr::mutate(stock_type = "UM_H"),
     readxl::read_excel(filename, range = "LimitingStkComplete mod!J242:DL313", col_names = column.names, .name_repair = "unique_quiet") |>

--- a/R/read_management.R
+++ b/R/read_management.R
@@ -17,7 +17,8 @@ read_management_chin = function(file){
   man.page <- suppressMessages(readxl::read_excel(file,
                                                   sheet = "RMP_Mgmt_Criteria",
                                                   range = "A1:M85",
-                                                  col_names = FALSE))
+                                                  col_names = FALSE,
+                                                  .name_repair = "unique_quiet"))
   ## split based on whitespage rows
   n <- rowSums(is.na(man.page)) == ncol(man.page)
   cs <- cumsum(n) + 1

--- a/R/read_overview.R
+++ b/R/read_overview.R
@@ -47,7 +47,8 @@ read_overview <- function(path) {
 read_overview_complete <- function(path) {
   raw <- readxl::read_excel(path,
     sheet = "ER_ESC_Overview_New",
-    range = "A2:H34"
+    range = "A2:H34",
+    .name_repair = "unique_quiet"
   ) |> janitor::clean_names()
 
   ## some annoyances: manually construct season and primary stock labels to provide clarity. Based on

--- a/R/read_tnt_allocation_chin.R
+++ b/R/read_tnt_allocation_chin.R
@@ -42,7 +42,8 @@ read_tnt_allocation_chin = function(xlsxFile){
 
 
   raw = readxl::read_excel(xlsxFile, sheet = "2A_CU&M_H+N",
-                           col_names = FALSE)
+                           col_names = FALSE,
+                           .name_repair = "unique_quiet")
   ## rows and columns identified by hand
   df = raw[c(9, 10, 56, 57), c(4:10, 15:21, 25:33)] |>
     t() |>
@@ -57,7 +58,8 @@ read_tnt_allocation_chin = function(xlsxFile){
 
   ## elwha and dungeness separate calculations
   raw = readxl::read_excel(xlsxFile, sheet = "JDF",
-                           col_names = FALSE)
+                           col_names = FALSE,
+                           .name_repair = "unique_quiet")
   ## trimming to the relevant region
   dat.jdf = raw[-(1:7),15:18]
   ## need to trim off the bottom section with summaries

--- a/inst/tamm-visualizer.qmd
+++ b/inst/tamm-visualizer.qmd
@@ -44,7 +44,7 @@ source("tamm-report-parameters-intermediate.R")
 dat <- TAMMsupport::read_limiting_stock(tamm.full) |>
   rename(fishery_id = FisheryID)
 ## figure out if this is a coho or chinook, add as attribute so we can used FRAMR^2 filters
-run.num <- read_excel(tamm.full, range = "1!B2", col_names = FALSE)
+run.num <- read_excel(tamm.full, range = "1!B2", col_names = FALSE, .name_repair = "unique_quiet")
 if (grepl("Chin", run.num)) {
   attr(dat, "species") <- "CHINOOK"
 }


### PR DESCRIPTION
Updated read_limiting_stock to include the first two blocks of the Chinook `limiting_stock_complete mod` tab: all natural and all hatchery mortalities. `stock_category` labels also updated to use "AD_*" instead of "M_*" for marked fish, to be more consistent with nomenclature elsewhere.